### PR TITLE
Imp: initial woocommerce advanced support

### DIFF
--- a/assets/front/css/dev-common.css
+++ b/assets/front/css/dev-common.css
@@ -153,6 +153,12 @@ input, textarea, button, select, label { font-family: inherit; }
 .themeform input[type="url"],
 .themeform input[type="tel"],
 .themeform input[type="number"],
+/* woocommerce */
+.themeform .woocommerce #respond input#submit,
+.themeform .woocommerce a.button,
+.themeform .woocommerce button.button,
+.themeform .woocommerce input.button,
+/* end woocommerce */
 .themeform input[type="submit"],
 .themeform select,
 .themeform button,
@@ -181,11 +187,43 @@ input, textarea, button, select, label { font-family: inherit; }
 .themeform select:focus,
 .themeform textarea:focus { border-color: #ccc; color: #444; -webkit-box-shadow: 0 0 3px rgba(0,0,0,0.1); box-shadow: 0 0 3px rgba(0,0,0,0.1); }
 .themeform label .required { color: #3b8dbd; }
+
 .themeform input[type="submit"],
 .themeform button[type="submit"] { background: #3b8dbd; color: #fff; padding: 8px 14px; font-weight: 600; display: inline-block; border: none; cursor: pointer; -webkit-border-radius: 3px; border-radius: 3px; }
-.themeform input[type="submit"]:hover,
-.themeform button[type="submit"]:hover { background: #444; }
 
+/* woocommerce */
+/* secondary color for the normal buttons */
+
+.themeform .woocommerce #respond input#submit,
+.themeform .woocommerce a.button,
+.themeform .woocommerce button.button,
+.themeform .woocommerce input.button { background: #82b965; color: #fff; padding: 8px 14px; font-weight: 600; display: inline-block; border: none; cursor: pointer; -webkit-border-radius: 3px; border-radius: 3px;
+}
+
+/* primary color for the important buttons (Buy) */
+.themeform .woocommerce #respond input#submit.alt,
+.themeform .woocommerce a.button.alt,
+.themeform .woocommerce button.button.alt,
+.themeform .woocommerce input.button.alt { background: #3b8dbd; }
+/* end woocommerce */
+
+/* woocommerce: background and color on hover */
+.themeform .woocommerce #respond input#submit:hover,
+.themeform .woocommerce a.button:hover,
+.themeform .woocommerce button.button:hover,
+.themeform .woocommerce input.button:hover,
+.themeform .woocommerce #respond input#submit.alt:hover,
+.themeform .woocommerce a.button.alt:hover,
+.themeform .woocommerce button.button.alt:hover,
+.themeform .woocommerce input.button.alt:hover
+/* end woocommerce */
+.themeform input[type="submit"]:hover,
+.themeform button[type="submit"]:hover { background: #444; color: #fff; }
+/* woocommerce checkout button specific */
+.themeform #add_payment_method .wc-proceed-to-checkout a.checkout-button,
+.woocommerce-cart .themeform .wc-proceed-to-checkout a.checkout-button,
+.woocommerce-checkout .themeform .wc-proceed-to-checkout a.checkout-button { display: block; padding: 1em; }
+/* end woocommerce */
 .themeform.searchform div { position: relative; }
 .themeform.searchform div input { padding-left: 26px; line-height: 20px; }
 .themeform.searchform div:after { color: #ccc; line-height: 24px; font-size: 14px; content: "\f002"; position: absolute; left: 10px; top: 6px; font-family: FontAwesome; }
@@ -205,6 +243,10 @@ input, textarea, button, select, label { font-family: inherit; }
 .entry li { margin: 0; }
 .entry ul li,
 .entry ol ul li { list-style: square; }
+/* woocommerce */
+.woocommerce .entry #reviews #comments ol.commentlist li,
+.entry .woocommerce ul li { list-style: none; }
+/* end woocommerce */
 .entry ol li,
 .entry ol ul ol li { list-style: decimal; }
 .entry dt { font-weight: 600;}
@@ -268,15 +310,34 @@ transition: all .2s ease;
 /* ------------------------------------ */
 h1, h2, h3, h4, h5, h6 { color: #444; font-weight: 600; -ms-word-wrap: break-word; word-wrap: break-word; }
 .entry h1 span, .entry h2 span, .entry h3 span, .entry h4 span, .entry h5 span, .entry h6 span { color: #bbb; }
+/* woocommerce */
+.woocommerce div.product h1.product_title,
+.woocommerce-Tabs-panel.entry-content h2,
+.woocommerce .cross-sells h2,
+.woocommerce .upsells.products h2,
+.woocommerce .related.products h2,
+/* end woocommerce */
 .entry h1,.entry h2,.entry h3,.entry h4,.entry h5,.entry h6  { margin-bottom: 14px; font-weight: 400; line-height: 1.3em; }
+/* woocommerce */
+.woocommerce div.product h1.product_title,
+/* end woocommerce */
 .entry h1 { font-size: 38px; letter-spacing: -1px; }
 .entry h2 { font-size: 34px; letter-spacing: -0.7px; }
 .entry h3 { font-size: 28px; letter-spacing: -0.5px; }
+/* woocommerce */
+.woocommerce-Tabs-panel.entry-content h2 { margin-top: 20px;}
+.woocommerce-Tabs-panel.entry-content h2,
+.woocommerce .cross-sells h2,
+.woocommerce .upsells.products h2,
+.woocommerce .related.products h2,
+/* woocommerce */
 .entry h4 { font-size: 24px; letter-spacing: -0.3px; }
 .entry h5 { font-size: 20px; font-weight: 600; }
 .entry h6 { font-size: 18px; font-weight: 600; text-transform: uppercase; }
 
 .heading,
+/* woocommerce */
+.woocommerce #reviews h3,
 #reply-title { font-weight: normal; font-size: 18px; text-transform: uppercase; font-weight: 600; margin-bottom: 1em; }
 .heading i { font-size: 22px; margin-right: 6px; }
 
@@ -839,7 +900,9 @@ box-shadow: inset 0 1px 0 rgba(0,0,0,0.05); }
 .featured.flexslider { padding-bottom: 30px; margin-bottom: 30px; border-bottom: 1px solid #eee; }
 .featured .post { margin-bottom: 0; }
 .featured .post-title { font-size: 34px; letter-spacing: -0.7px; line-height: 1.4em; }
-
+/* woocommerce */
+.products .featured { border-bottom: none }
+/* end woocommerce */
 /*  post : custom loop
 /* ------------------------------------ */
 .post-list { margin-right: -30px; }
@@ -1353,10 +1416,27 @@ box-shadow: inset 0 1px 0 rgba(255,255,255,0.25); }
 /* ------------------------------------------------------------------------- *
  *  Comments
 /* ------------------------------------------------------------------------- */
+/* woocommerce */
+.entry .woocommerce .woocommerce-tabs.wc-tabs-wrapper #comments { margin-top: 0;},
+/* end woocoommerce */
 #comments { margin-top: 20px; }
 #pinglist-container { display: none; }
 
 .comment-tabs { border-bottom: 2px solid #eee; margin-bottom: 20px; }
+
+/* woocommerce */
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs { border-bottom: 2px solid #eee; margin-bottom: 20px; overflow: visible;  margin: 0; padding: 0; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs::before {  border-bottom: none; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li { padding: 0; font-size: .88em; float: left; margin: 0 0 -2px; background: transparent !important; border: none!important; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li:after,
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li:before { content: none; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li a{ line-height: 1.55em; font-weight: 600; padding: 0 10px 10px; display: block; color: #aaa; border-bottom: 2px solid #eee; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li a:hover { color: #444; border-color: #ccc; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li.active a { color: #3b8dbd;  border-bottom-color: #3b8dbd; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li span { background-color: #eee; padding: 0 6px; margin-left: 8px; -webkit-border-radius: 4px; border-radius: 4px; }
+.entry.woocommerce div.product .woocommerce-tabs ul.tabs li i { margin-right: 6px; }
+/* end woocommerce */
+
 .comment-tabs li { float: left; margin-bottom: -2px; }
 .comment-tabs li a { font-weight: 600; padding: 0 10px 10px; display: block; color: #aaa; border-bottom: 2px solid #eee; }
 .comment-tabs li a:hover { color: #444; border-color: #ccc; }

--- a/functions/dynamic-styles.php
+++ b/functions/dynamic-styles.php
@@ -37,8 +37,7 @@ if ( ! function_exists( 'hu_google_fonts' ) ) {
       return;
 
     if ( hu_get_option( 'font' ) == 'titillium-web-ext' ) { echo '<link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,300italic,300,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
-    if ( hu_get_option( 'font' ) == 'droid-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=Droid+Serif:400,400italic,700" rel="stylesheet" type="text/css">'."
-"; }
+    if ( hu_get_option( 'font' ) == 'droid-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=Droid+Serif:400,400italic,700" rel="stylesheet" type="text/css">'."\n"; }
     if ( hu_get_option( 'font' ) == 'source-sans-pro' ) { echo '<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300italic,300,400italic,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
     if ( hu_get_option( 'font' ) == 'lato' ) { echo '<link href="//fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700" rel="stylesheet" type="text/css">'."\n"; }
     if ( hu_get_option( 'font' ) == 'raleway' ) { echo '<link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">'."\n"; }
@@ -133,8 +132,7 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
       }
       // primary color
       if ( hu_get_option('color-1') != '#3b8dbd' ) {
-        $styles[]  = '
-::selection { background-color: '.hu_get_option('color-1').'; }
+        $styles[]  = '::selection { background-color: '.hu_get_option('color-1').'; }
 ::-moz-selection { background-color: '.hu_get_option('color-1').'; }';
 
         $_primary_color_color_prop_selectors = array(
@@ -188,8 +186,7 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
         $_primary_color_background_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_primary_color_background_color_prop_selectors', $_primary_color_background_color_prop_selectors ) );
         $styles[] = $_primary_color_background_color_prop_selectors ? $_primary_color_background_color_prop_selectors . '{ background-color: '.hu_get_option('color-1').'; }'."{$glue}" : '';
 
-        $styles[] ='
-.post-format .format-container { border-color: '.hu_get_option('color-1').'; }';
+        $styles[] ='.post-format .format-container { border-color: '.hu_get_option('color-1').'; }';
 
         $_primary_color_border_bottom_color_prop_selectors = array(
           '.s1 .alx-tabs-nav li.active a',
@@ -207,8 +204,7 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
 
       // secondary color
       if ( hu_get_option('color-2') != '#82b965' ) {
-        $styles[] = '
-.s2 .post-nav li a:hover i,
+        $styles[] = '.s2 .post-nav li a:hover i,
 .s2 .widget_rss ul li a,
 .s2 .widget_calendar a,
 .s2 .alx-tab .tab-item-category a,
@@ -218,7 +214,6 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
 .s2 .alx-posts li:hover .post-item-title a { color: '.hu_get_option('color-2').'; }
 ';
       $_secondary_color_background_color_prop_selectors = array(
-
         '.s2 .sidebar-top',
         '.s2 .sidebar-toggle',
         '.post-comments',
@@ -230,15 +225,13 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
     $_secondary_color_background_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_secondary_color_background_color_prop_selectors', $_secondary_color_background_color_prop_selectors ) );
     $styles[] = $_secondary_color_background_color_prop_selectors ? $_secondary_color_background_color_prop_selectors . '{ background-color: '.hu_get_option('color-2').'; }'."{$glue}" : '';
 
-    $styles[] ='
-.s2 .alx-tabs-nav li.active a { border-bottom-color: '.hu_get_option('color-2').'; }
+    $styles[] ='.s2 .alx-tabs-nav li.active a { border-bottom-color: '.hu_get_option('color-2').'; }
 .post-comments span:before { border-right-color: '.hu_get_option('color-2').'; }
         ';
       }
       // topbar color
       if ( hu_get_option('color-topbar') != '#26272b' ) {
-        $styles[] = '
-.search-expand,
+        $styles[] = '.search-expand,
 #nav-topbar.nav-container { background-color: '.hu_get_option('color-topbar').'; }
 @media only screen and (min-width: 720px) {
   #nav-topbar .nav ul { background-color: '.hu_get_option('color-topbar').'; }
@@ -247,8 +240,7 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
       }
       // header color
       if ( hu_get_option('color-header') != '#33363b' ) {
-        $styles[] = '
-#header { background-color: '.hu_get_option('color-header').'; }
+        $styles[] = '#header { background-color: '.hu_get_option('color-header').'; }
 @media only screen and (min-width: 720px) {
   #nav-header .nav ul { background-color: '.hu_get_option('color-header').'; }
 }
@@ -256,8 +248,7 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
       }
       // header menu color
       if ( hu_get_option('color-header-menu') != '' ) {
-        $styles[] = '
-#nav-header.nav-container { background-color: '.hu_get_option('color-header-menu').'; }
+        $styles[] = '#nav-header.nav-container { background-color: '.hu_get_option('color-header-menu').'; }
 @media only screen and (min-width: 720px) {
   #nav-header .nav ul { background-color: '.hu_get_option('color-header-menu').'; }
 }

--- a/functions/dynamic-styles.php
+++ b/functions/dynamic-styles.php
@@ -36,23 +36,24 @@ if ( ! function_exists( 'hu_google_fonts' ) ) {
     if ( ! hu_is_checked('dynamic-styles') )
       return;
 
-    if ( hu_get_option( 'font' ) == 'titillium-web-ext' ) { echo '<link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,300italic,300,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'droid-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=Droid+Serif:400,400italic,700" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'source-sans-pro' ) { echo '<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300italic,300,400italic,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'lato' ) { echo '<link href="//fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'raleway' ) { echo '<link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'ubuntu' ) { echo '<link href="//fonts.googleapis.com/css?family=Ubuntu:400,400italic,300italic,300,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'ubuntu-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Ubuntu:400,400italic,300italic,300,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'roboto-condensed' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Condensed:400,300italic,300,400italic,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'roboto-condensed-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Condensed:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'roboto-slab' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Slab:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'roboto-slab-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Slab:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'playfair-display' ) { echo '<link href="//fonts.googleapis.com/css?family=Playfair+Display:400,400italic,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'playfair-display-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Playfair+Display:400,400italic,700&subset=latin,cyrillic" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'open-sans' ) { echo '<link href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,300italic,300,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'open-sans-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,300italic,300,600&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'pt-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic&subset=latin,latin-ext" rel="stylesheet" type="text/css">'. "\n"; }
-    if ( hu_get_option( 'font' ) == 'pt-serif-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'. "\n"; }
+    if ( hu_get_option( 'font' ) == 'titillium-web-ext' ) { echo '<link href="//fonts.googleapis.com/css?family=Titillium+Web:400,400italic,300italic,300,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'droid-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=Droid+Serif:400,400italic,700" rel="stylesheet" type="text/css">'."
+"; }
+    if ( hu_get_option( 'font' ) == 'source-sans-pro' ) { echo '<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300italic,300,400italic,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'lato' ) { echo '<link href="//fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'raleway' ) { echo '<link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'ubuntu' ) { echo '<link href="//fonts.googleapis.com/css?family=Ubuntu:400,400italic,300italic,300,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'ubuntu-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Ubuntu:400,400italic,300italic,300,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'roboto-condensed' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Condensed:400,300italic,300,400italic,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'roboto-condensed-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Condensed:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'roboto-slab' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Slab:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'roboto-slab-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Roboto+Slab:400,300italic,300,400italic,700&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'playfair-display' ) { echo '<link href="//fonts.googleapis.com/css?family=Playfair+Display:400,400italic,700&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'playfair-display-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Playfair+Display:400,400italic,700&subset=latin,cyrillic" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'open-sans' ) { echo '<link href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,300italic,300,600&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'open-sans-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,300italic,300,600&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'pt-serif' ) { echo '<link href="//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic&subset=latin,latin-ext" rel="stylesheet" type="text/css">'."\n"; }
+    if ( hu_get_option( 'font' ) == 'pt-serif-cyr' ) { echo '<link href="//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic&subset=latin,cyrillic-ext" rel="stylesheet" type="text/css">'."\n"; }
   }
 
 }
@@ -70,101 +71,143 @@ if ( ! function_exists( 'hu_dynamic_css' ) ) {
       $color_1 = hu_get_option('color-1');
       $color_1_rgb = hu_hex2rgb($color_1);
 
-      // start output
-      $styles = '<style type="text/css">'."\n";
-      $styles .= '/* Dynamic CSS: For no styles in head, copy and put the css below in your child theme\'s style.css, disable dynamic styles */'."\n";
+      $glue    = hu_is_checked('minified-css') ? '' : "\n";
 
+      //start computing style
+      $styles   = array();
       // google fonts
-      if ( hu_get_option( 'font' ) == 'titillium-web-ext' ) { $styles .= 'body { font-family: "Titillium Web", Arial, sans-serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'droid-serif' ) { $styles .= 'body { font-family: "Droid Serif", serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'source-sans-pro' ) { $styles .= 'body { font-family: "Source Sans Pro", Arial, sans-serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'lato' ) { $styles .= 'body { font-family: "Lato", Arial, sans-serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'raleway' ) { $styles .= 'body { font-family: "Raleway", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'ubuntu' ) || ( hu_get_option( 'font' ) == 'ubuntu-cyr' ) ) { $styles .= 'body { font-family: "Ubuntu", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'roboto-condensed' ) || ( hu_get_option( 'font' ) == 'roboto-condensed-cyr' ) ) { $styles .= 'body { font-family: "Roboto Condensed", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'roboto-slab' ) || ( hu_get_option( 'font' ) == 'roboto-slab-cyr' ) ) { $styles .= 'body { font-family: "Roboto Slab", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'playfair-display' ) || ( hu_get_option( 'font' ) == 'playfair-display-cyr' ) ) { $styles .= 'body { font-family: "Playfair Display", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'open-sans' ) || ( hu_get_option( 'font' ) == 'open-sans-cyr' ) ) { $styles .= 'body { font-family: "Open Sans", Arial, sans-serif; }'."\n"; }
-      if ( ( hu_get_option( 'font' ) == 'pt-serif' ) || ( hu_get_option( 'font' ) == 'pt-serif-cyr' ) ) { $styles .= 'body { font-family: "PT Serif", serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'arial' ) { $styles .= 'body { font-family: Arial, sans-serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'georgia' ) { $styles .= 'body { font-family: Georgia, serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'verdana' ) { $styles .= 'body { font-family: Verdana, sans-serif; }'."\n"; }
-      if ( hu_get_option( 'font' ) == 'tahoma' ) { $styles .= 'body { font-family: Tahoma, sans-serif; }'."\n"; }
+      $google_font = hu_get_option( 'font' );
+
+      switch ( $google_font ) {
+        case 'titillium-web-ext'    : $styles[] = 'body { font-family: "Titillium Web", Arial, sans-serif; }';
+                                      break;
+        case 'droid-serif'          : $styles[] = 'body { font-family: "Droid Serif", serif; }';
+                                      break;
+        case 'source-sans-pro'      : $styles[] = 'body { font-family: "Source Sans Pro", Arial, sans-serif; }';
+                                      break;
+        case 'lato'                 : $styles[] = 'body { font-family: "Lato", Arial, sans-serif; }';
+                                      break;
+        case 'raleway'              : $styles[] = 'body { font-family: "Raleway", Arial, sans-serif; }';
+                                      break;
+        case 'ubunty'               :
+        case 'ubuntu-cyr'           : $styles[] = 'body { font-family: "Ubuntu", Arial, sans-serif; }';
+                                      break;
+        case 'roboto-condensed'     :
+        case 'roboto-condensed-cyr' : $styles[] = 'body { font-family: "Roboto Condensed", Arial, sans-serif; }';
+                                      break;
+        case 'roboto-slab'          :
+        case 'roboto-slab-cyr'      : $styles[] = 'body { font-family: "Roboto Slab", Arial, sans-serif; }';
+                                      break;
+        case 'playfair-display'     :
+        case 'playfair-display-cyr' : $styles[] = 'body { font-family: "Playfair Display", Arial, sans-serif; }';
+                                      break;
+        case 'open-sans'            :
+        case 'open-sans-cyr'        : $styles[] = 'body { font-family: "Open Sans", Arial, sans-serif; }';
+                                      break;
+        case 'pt-serif'             :
+        case 'pt-serif-cyr'         : $styles[] ='body { font-family: "PT Serif", serif; }';
+                                      break;
+        case 'arial'                : $styles[] = 'body { font-family: Arial, sans-serif; }';
+                                      break;
+        case 'georgia'              : $styles[] = 'body { font-family: Georgia, serif; }';
+                                      break;
+        case 'verdana'              : $styles[] = 'body { font-family: Verdana, sans-serif; }';
+                                      break;
+        case 'tahoma'               : $styles[] = 'body { font-family: Tahoma, sans-serif; }';
+                                      break;
+      }
 
       // container width
       if ( hu_get_option('container-width') != '1380' ) {
         if ( hu_is_checked( 'boxed' ) ) {
-          $styles .= '.boxed #wrapper, .container-inner { max-width: '.hu_get_option('container-width').'px; }'."\n";
+          $styles[] = '.boxed #wrapper, .container-inner { max-width: '.hu_get_option('container-width').'px; }';
         }
         else {
-          $styles .= '.container-inner { max-width: '.hu_get_option('container-width').'px; }'."\n";
+          $styles[] = '.container-inner { max-width: '.hu_get_option('container-width').'px; }';
         }
       }
 
       // sidebar padding
       if ( hu_get_option('sidebar-padding') != '30' ) {
-        $styles .= '.sidebar .widget { padding-left: '.hu_get_option('sidebar-padding').'px; padding-right: '.hu_get_option('sidebar-padding').'px; padding-top: '.hu_get_option('sidebar-padding').'px; }'."\n";
+        $styles[]  = '.sidebar .widget { padding-left: '.hu_get_option('sidebar-padding').'px; padding-right: '.hu_get_option('sidebar-padding').'px; padding-top: '.hu_get_option('sidebar-padding').'px; }';
       }
       // primary color
       if ( hu_get_option('color-1') != '#3b8dbd' ) {
-        $styles .= '
+        $styles[]  = '
 ::selection { background-color: '.hu_get_option('color-1').'; }
-::-moz-selection { background-color: '.hu_get_option('color-1').'; }
+::-moz-selection { background-color: '.hu_get_option('color-1').'; }';
 
-a,
-.themeform label .required,
-#flexslider-featured .flex-direction-nav .flex-next:hover,
-#flexslider-featured .flex-direction-nav .flex-prev:hover,
-.post-hover:hover .post-title a,
-.post-title a:hover,
-.s1 .post-nav li a:hover i,
-.content .post-nav li a:hover i,
-.post-related a:hover,
-.s1 .widget_rss ul li a,
-#footer .widget_rss ul li a,
-.s1 .widget_calendar a,
-#footer .widget_calendar a,
-.s1 .alx-tab .tab-item-category a,
-.s1 .alx-posts .post-item-category a,
-.s1 .alx-tab li:hover .tab-item-title a,
-.s1 .alx-tab li:hover .tab-item-comment a,
-.s1 .alx-posts li:hover .post-item-title a,
-#footer .alx-tab .tab-item-category a,
-#footer .alx-posts .post-item-category a,
-#footer .alx-tab li:hover .tab-item-title a,
-#footer .alx-tab li:hover .tab-item-comment a,
-#footer .alx-posts li:hover .post-item-title a,
-.comment-tabs li.active a,
-.comment-awaiting-moderation,
-.child-menu a:hover,
-.child-menu .current_page_item > a,
-.wp-pagenavi a { color: '.hu_get_option('color-1').'; }
+        $_primary_color_color_prop_selectors = array(
+          'a',
+          '.themeform label .required',
+          '#flexslider-featured .flex-direction-nav .flex-next:hover',
+          '#flexslider-featured .flex-direction-nav .flex-prev:hover',
+          '.post-hover:hover .post-title a',
+          '.post-title a:hover',
+          '.s1 .post-nav li a:hover i',
+          '.content .post-nav li a:hover i',
+          '.post-related a:hover',
+          '.s1 .widget_rss ul li a',
+          '#footer .widget_rss ul li a',
+          '.s1 .widget_calendar a',
+          '#footer .widget_calendar a',
+          '.s1 .alx-tab .tab-item-category a',
+          '.s1 .alx-posts .post-item-category a',
+          '.s1 .alx-tab li:hover .tab-item-title a',
+          '.s1 .alx-tab li:hover .tab-item-comment a',
+          '.s1 .alx-posts li:hover .post-item-title a',
+          '#footer .alx-tab .tab-item-category a',
+          '#footer .alx-posts .post-item-category a',
+          '#footer .alx-tab li:hover .tab-item-title a',
+          '#footer .alx-tab li:hover .tab-item-comment a',
+          '#footer .alx-posts li:hover .post-item-title a',
+          '.comment-tabs li.active a',
+          '.comment-awaiting-moderation',
+          '.child-menu a:hover',
+          '.child-menu .current_page_item > a',
+          '.wp-pagenavi a'
+        );
 
-.themeform input[type="submit"],
-.themeform button[type="submit"],
-.s1 .sidebar-top,
-.s1 .sidebar-toggle,
-#flexslider-featured .flex-control-nav li a.flex-active,
-.post-tags a:hover,
-.s1 .widget_calendar caption,
-#footer .widget_calendar caption,
-.author-bio .bio-avatar:after,
-.commentlist li.bypostauthor > .comment-body:after,
-.commentlist li.comment-author-admin > .comment-body:after { background-color: '.hu_get_option('color-1').'; }
+        $_primary_color_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_primary_color_color_prop_selectors', $_primary_color_color_prop_selectors ) );
+        $styles[] = $_primary_color_color_prop_selectors ? $_primary_color_color_prop_selectors . '{ color: '.hu_get_option('color-1').'; }'."{$glue}" : '';
 
-.post-format .format-container { border-color: '.hu_get_option('color-1').'; }
+        $_primary_color_background_color_prop_selectors = array(
+          '.themeform input[type="submit"]',
+          '.themeform button[type="submit"]',
+          '.s1 .sidebar-top',
+          '.s1 .sidebar-toggle',
+          '#flexslider-featured .flex-control-nav li a.flex-active',
+          '.post-tags a:hover',
+          '.s1 .widget_calendar caption',
+          '#footer .widget_calendar caption',
+          '.author-bio .bio-avatar:after',
+          '.commentlist li.bypostauthor > .comment-body:after',
+          '.commentlist li.comment-author-admin > .comment-body:after'
+        );
 
-.s1 .alx-tabs-nav li.active a,
-#footer .alx-tabs-nav li.active a,
-.comment-tabs li.active a,
-.wp-pagenavi a:hover,
-.wp-pagenavi a:active,
-.wp-pagenavi span.current { border-bottom-color: '.hu_get_option('color-1').'!important; }
-        '."\n";
-      }
+        $_primary_color_background_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_primary_color_background_color_prop_selectors', $_primary_color_background_color_prop_selectors ) );
+        $styles[] = $_primary_color_background_color_prop_selectors ? $_primary_color_background_color_prop_selectors . '{ background-color: '.hu_get_option('color-1').'; }'."{$glue}" : '';
+
+        $styles[] ='
+.post-format .format-container { border-color: '.hu_get_option('color-1').'; }';
+
+        $_primary_color_border_bottom_color_prop_selectors = array(
+          '.s1 .alx-tabs-nav li.active a',
+          '#footer .alx-tabs-nav li.active a',
+          '.comment-tabs li.active a',
+          '.wp-pagenavi a:hover',
+          '.wp-pagenavi a:active',
+          '.wp-pagenavi span.current'
+        );
+
+        $_primary_color_border_bottom_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_primary_color_border_bottom_color_prop_selectors', $_primary_color_border_bottom_color_prop_selectors ) );
+        $styles[] = $_primary_color_border_bottom_color_prop_selectors ? $_primary_color_border_bottom_color_prop_selectors . '{ border-bottom-color: '.hu_get_option('color-1').'!important; }'."{$glue}" : '';
+
+      }//end primary color
+
       // secondary color
       if ( hu_get_option('color-2') != '#82b965' ) {
-        $styles .= '
+        $styles[] = '
 .s2 .post-nav li a:hover i,
 .s2 .widget_rss ul li a,
 .s2 .widget_calendar a,
@@ -173,61 +216,68 @@ a,
 .s2 .alx-tab li:hover .tab-item-title a,
 .s2 .alx-tab li:hover .tab-item-comment a,
 .s2 .alx-posts li:hover .post-item-title a { color: '.hu_get_option('color-2').'; }
+';
+      $_secondary_color_background_color_prop_selectors = array(
 
-.s2 .sidebar-top,
-.s2 .sidebar-toggle,
-.post-comments,
-.jp-play-bar,
-.jp-volume-bar-value,
-.s2 .widget_calendar caption { background-color: '.hu_get_option('color-2').'; }
+        '.s2 .sidebar-top',
+        '.s2 .sidebar-toggle',
+        '.post-comments',
+        '.jp-play-bar',
+        '.jp-volume-bar-value',
+        '.s2 .widget_calendar caption'
+    );
 
+    $_secondary_color_background_color_prop_selectors = implode( ",{$glue}", apply_filters( 'hu_dynamic_secondary_color_background_color_prop_selectors', $_secondary_color_background_color_prop_selectors ) );
+    $styles[] = $_secondary_color_background_color_prop_selectors ? $_secondary_color_background_color_prop_selectors . '{ background-color: '.hu_get_option('color-2').'; }'."{$glue}" : '';
+
+    $styles[] ='
 .s2 .alx-tabs-nav li.active a { border-bottom-color: '.hu_get_option('color-2').'; }
 .post-comments span:before { border-right-color: '.hu_get_option('color-2').'; }
-        '."\n";
+        ';
       }
       // topbar color
       if ( hu_get_option('color-topbar') != '#26272b' ) {
-        $styles .= '
+        $styles[] = '
 .search-expand,
 #nav-topbar.nav-container { background-color: '.hu_get_option('color-topbar').'; }
 @media only screen and (min-width: 720px) {
   #nav-topbar .nav ul { background-color: '.hu_get_option('color-topbar').'; }
 }
-        '."\n";
+        ';
       }
       // header color
       if ( hu_get_option('color-header') != '#33363b' ) {
-        $styles .= '
+        $styles[] = '
 #header { background-color: '.hu_get_option('color-header').'; }
 @media only screen and (min-width: 720px) {
   #nav-header .nav ul { background-color: '.hu_get_option('color-header').'; }
 }
-        '."\n";
+        ';
       }
       // header menu color
       if ( hu_get_option('color-header-menu') != '' ) {
-        $styles .= '
+        $styles[] = '
 #nav-header.nav-container { background-color: '.hu_get_option('color-header-menu').'; }
 @media only screen and (min-width: 720px) {
   #nav-header .nav ul { background-color: '.hu_get_option('color-header-menu').'; }
 }
-        '."\n";
+        ';
       }
       // footer color
       if ( hu_get_option('color-footer') != '#33363b' ) {
-        $styles .= '#footer-bottom { background-color: '.hu_get_option('color-footer').'; }'."\n";
+        $styles[] = '#footer-bottom { background-color: '.hu_get_option('color-footer').'; }';
       }
       // header logo max-height
       if ( hu_get_option('logo-max-height') != '60' ) {
-        $styles .= '.site-title a img { max-height: '.hu_get_option('logo-max-height').'px; }'."\n";
+        $styles[] = '.site-title a img { max-height: '.hu_get_option('logo-max-height').'px; }';
       }
       // image border radius
       if ( hu_get_option('image-border-radius') != '0' ) {
-        $styles .= 'img { -webkit-border-radius: '.hu_get_option('image-border-radius').'px; border-radius: '.hu_get_option('image-border-radius').'px; }'."\n";
+        $styles[] = 'img { -webkit-border-radius: '.hu_get_option('image-border-radius').'px; border-radius: '.hu_get_option('image-border-radius').'px; }';
       }
       // // body background (old)
       // if ( hu_get_option('body-background') != '#eaeaea' ) {
-      //  $styles .= 'body { background-color: '.hu_get_option('body-background').'; }'."\n";
+      //  $styles .= 'body { background-color: '.hu_get_option('body-background').'; }';
       // }
 
       // body background (@fromfull) => keep on wp.org
@@ -235,7 +285,7 @@ a,
       if ( ! empty( $body_bg ) ) {
         //for users of wp.org version prior to 3.0+, this option is an hex color string.
         if ( is_string($body_bg) ) {
-          $styles .= 'body { background-color: ' . $body_bg . '; }'."\n";
+          $styles[] = 'body { background-color: ' . $body_bg . '; }';
         } elseif ( is_array($body_bg) ) {
           //set-up sub-options
           foreach ( array( 'color', 'image', 'attachment', 'position', 'size', 'repeat' ) as $prop ) {
@@ -252,18 +302,27 @@ a,
             $body_bg_style .= 'background-attachment:'.$body_bg[ 'background-attachment' ].';';
             if ( $body_bg[ 'background-size' ] )
               $body_bg_style .=  'background-size: '.$body_bg['background-size'].';';
-            $styles .= 'body {'. $body_bg_style . "}\n";
+            $styles[] = 'body {'. $body_bg_style . "}\n";
           }
           elseif ( $body_bg['background-color'] ) {
-            $styles .= 'body { background-color: '.$body_bg['background-color'].'; }'."\n";
+            $styles[] = 'body { background-color: '.$body_bg['background-color'].'; }';
           }
         }
       }
+      // end computing
 
-      $styles .= '</style>'."\n";
-      // end output
+      if ( empty ( $styles ) )
+        return;
 
-      echo $styles;
+      // start output
+      $_p_styles   = array( '<style type="text/css">' );
+      $_p_styles[] = '/* Dynamic CSS: For no styles in head, copy and put the css below in your child theme\'s style.css, disable dynamic styles */';
+      $_p_styles[] = implode( "{$glue}", $styles );
+      $_p_styles[] = '</style>'."\n";
+      //end output;
+
+      //print
+      echo implode( "{$glue}", $_p_styles );
     }
 
 }

--- a/functions/init-admin.php
+++ b/functions/init-admin.php
@@ -207,7 +207,7 @@ function hu_custom_meta_boxes() {
       'id'          => 'post-options',
       'title'       => 'Post Options',
       'desc'        => '',
-      'pages'       => array( 'post' ),
+      'pages'       => apply_filters( 'hu_custom_meta_boxes_post_options_in', array( 'post') ),
       'context'     => 'normal',
       'priority'    => 'high',
       'fields'      => array(

--- a/functions/init-after-setup-theme.php
+++ b/functions/init-after-setup-theme.php
@@ -77,8 +77,6 @@ if ( ! function_exists( 'hu_setup' ) ) {
     add_theme_support( 'post-thumbnails' );
     // Enable post format support
     add_theme_support( 'post-formats', array( 'audio', 'aside', 'chat', 'gallery', 'image', 'link', 'quote', 'status', 'video' ) );
-    // Declare WooCommerce support
-    add_theme_support( 'woocommerce' );
     // Add theme support for selective refresh for widgets.
     // Only add if the link manager is not enabled
     // cf WP core ticket #39451

--- a/functions/init-front.php
+++ b/functions/init-front.php
@@ -884,32 +884,6 @@ add_action( 'wp_footer', 'hu_ie_js_footer', 20 );
 
 
 
-/*  WooCommerce basic support
-/* ------------------------------------ */
-function hu_wc_wrapper_start() {
-  echo '<section class="content">';
-  echo '<div class="pad">';
-}
-function hu_wc_wrapper_end() {
-  echo '</div>';
-  echo '</section>';
-}
-remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
-remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
-add_action('woocommerce_before_main_content', 'hu_wc_wrapper_start', 10);
-add_action('woocommerce_after_main_content', 'hu_wc_wrapper_end', 10);
-
-
-/*  WP-PageNavi support - @devinsays (via GitHub)
-/* ------------------------------------ */
-function hu_deregister_styles() {
-  wp_deregister_style( 'wp-pagenavi' );
-}
-add_action( 'wp_print_styles', 'hu_deregister_styles', 100 );
-
-
-
-
 
 
 

--- a/functions/init-plugins-compat.php
+++ b/functions/init-plugins-compat.php
@@ -170,6 +170,17 @@ function hu_set_woocommerce_compat() {
   add_action('woocommerce_before_main_content', 'hu_theme_wrapper_start', 10);
   add_action('woocommerce_after_main_content', 'hu_theme_wrapper_end', 10);
 
+  //show hu custom single post meta boxes in product post type
+  add_filter( 'hu_custom_meta_boxes_post_options_in', 'hu_add_woocommerce_custom_meta_boxes_in_product');
+  if ( ! function_exists('hu_add_woocommerce_custom_meta_boxes_in_product') ) {
+    function hu_add_woocommerce_custom_meta_boxes_in_product( $array ) {
+      if ( is_array( $array ) && post_type_exists( 'product' ) )
+        array_push( $array, 'product' );
+      return $array;
+    }
+  }
+
+
   if ( apply_filters( 'hu_wc_basic_support', false ) ) {
     return;
   }


### PR DESCRIPTION
The whole concept about this task is to gracefully integrate WooCommerce in Hueman.
Possibly without using custom templates (=hard to maintain), using, therefore available filters.

Developed with WP_DEBUG_LOG true
No PHP/JS Warnings/Errors for the checked items below:

TODO:

- [x] Create main and dynamic specific CSS

- [x] Improve php theme wrappers to better "embed" woocommerce's contents

- [x] Woocommerce product tabs styled according to theme tabs (=comments)

- [x] Display Page/Single/Procuts(Shop) title in the Hueman way

- [x] Test Ajax add to cart in product lists and checkout => OK 

- [x] Test Ajax promotional code check in Cart page => OK 

- [x] Test Ajax update cart in Cart page => OK 

- [x] Test Checkout form (js validation, etc) => OK 

- [x] Test complete purchase (with a free product) => OK 

- [ ] Check mobile style (titles mainly)

- [ ] Improve woocommerce's tables (probably the hueman's tables are weakly styles)

- [ ] Improve look and feel of "My Account" page (totally not styled as of now)

- [ ] Improve look "Reviews list" to make it more similar to the theme's comments list

- [x] Ability to set the layout of the product post type (metaboxes missing)

- [x] Ability to set the widget areas of the product post type (metaboxes missing)

- [ ] Ability to set the layout of the shop page (no reaction on front to the selected layout,) - since it's actually a post type archive)

- [ ] Ability to set the widget areas of the shop page (no reaction on front to the selected widget areas - since it's actually a post type archive)

Consideration:
There are two filters:
- https://github.com/eri-trabiccolo/hueman/blob/woocommerce/functions/init-plugins-compat.php#L184
To me this should be turned to an option as there might be old users who had wc templates , we don't want to mess their stuff (not that much at least :))
- https://github.com/eri-trabiccolo/hueman/blob/woocommerce/functions/init-plugins-compat.php#L248
Ths should be turned to an option or set to false by default. It's to replace the reviews count (N) into `<span>N</span>` , it should not give any issue to be honest, but since that's a translated string
( "Reviews (%d)" ) I'm not totally sure it will be fine for ALL locales